### PR TITLE
デプロイシェル作ってみた

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+cd /home/isucon/isucon9-qualify && \
+git pull team master && \
+cd /home/isucon/isucon9-qualify/webapp/go/ && \
+make && \
+sudo systemctl restart mysql && \
+sudo systemctl restart isucari.golang && \
+sudo systemctl restart nginx


### PR DESCRIPTION
`cat deploy.sh | ssh hostname` で動作確認
今後は `ssh hostname deploy.sh` で実行できる想定

参考: https://blog.yuuk.io/entry/web-operations-isucon#:~:text=%E3%81%A8%E6%80%9D%E3%81%84%E3%81%BE%E3%81%99%E3%80%82-,%E3%83%87%E3%83%97%E3%83%AD%E3%82%A4%E8%87%AA%E5%8B%95%E5%8C%96,-Capistrano%E3%81%AE%E3%82%88%E3%81%86

~/.local/perl/bin/carton install
↑に相当するのがgoでは何かわからなかったのでとりあえずmakeに置き換え

sudo sysctl -p
↑カーネル設定を永続化するコマンドらしいがよくわかってないので追加してません